### PR TITLE
feat: joinable channels

### DIFF
--- a/apps/desktop/src/components/channels/ChannelBrowser.svelte
+++ b/apps/desktop/src/components/channels/ChannelBrowser.svelte
@@ -1,0 +1,135 @@
+<script lang="ts">
+  import Hash from "@lucide/svelte/icons/hash";
+  import Search from "@lucide/svelte/icons/search";
+  import Users from "@lucide/svelte/icons/users";
+  import type { Channel } from "@packages/api-client";
+
+  interface Props {
+    channels: Channel[];
+    isOpen: boolean;
+    onClose: () => void;
+    onJoin: (channelId: string) => void;
+  }
+
+  let { channels, isOpen, onClose, onJoin }: Props = $props();
+
+  let dialog: HTMLDialogElement | null = $state(null);
+  let searchQuery = $state("");
+  let showJoined = $state(false);
+
+  const filteredChannels = $derived(
+    channels
+      .filter((ch) => ch.type === "public")
+      .filter((ch) => (showJoined ? ch.joined : !ch.joined))
+      .filter((ch) =>
+        ch.name.toLowerCase().includes(searchQuery.toLowerCase()),
+      ),
+  );
+
+  $effect(() => {
+    if (isOpen) {
+      searchQuery = "";
+      showJoined = false;
+      dialog?.showModal();
+    } else {
+      dialog?.close();
+    }
+  });
+
+  function handleJoin(channelId: string) {
+    onJoin(channelId);
+  }
+</script>
+
+<dialog bind:this={dialog} class="modal" onclose={onClose}>
+  <div class="modal-box max-w-lg">
+    <h3 class="mb-4 text-lg font-medium">Browse Channels</h3>
+
+    <div class="mb-4 flex items-center gap-2">
+      <div class="relative flex-1">
+        <Search
+          class="text-muted absolute top-1/2 left-3 size-4 -translate-y-1/2"
+        />
+        <input
+          type="text"
+          placeholder="Search channels..."
+          class="input input-bordered w-full pl-10"
+          bind:value={searchQuery}
+        />
+      </div>
+    </div>
+
+    <div class="mb-4">
+      <div class="tabs tabs-box">
+        <button
+          type="button"
+          class={["tab", !showJoined && "tab-active"]}
+          onclick={() => (showJoined = false)}
+        >
+          Available
+        </button>
+        <button
+          type="button"
+          class={["tab", showJoined && "tab-active"]}
+          onclick={() => (showJoined = true)}
+        >
+          Joined
+        </button>
+      </div>
+    </div>
+
+    <div class="max-h-64 overflow-y-auto">
+      {#if filteredChannels.length === 0}
+        <div class="text-muted py-8 text-center text-sm">
+          {#if showJoined}
+            No joined channels
+          {:else}
+            No available channels to join
+          {/if}
+        </div>
+      {:else}
+        <ul class="flex flex-col gap-1">
+          {#each filteredChannels as channel (channel.id)}
+            <li
+              class="hover:bg-base-200 flex items-center justify-between rounded-lg px-3 py-2"
+            >
+              <div class="flex items-center gap-2">
+                <Hash class="text-muted size-4" />
+                <span class="font-medium">{channel.name}</span>
+                {#if channel.description}
+                  <span class="text-muted text-sm">{channel.description}</span>
+                {/if}
+              </div>
+              <div class="flex items-center gap-3">
+                <span class="text-muted flex items-center gap-1 text-xs">
+                  <Users class="size-3" />
+                  {channel.memberCount}
+                </span>
+                {#if !channel.joined}
+                  <button
+                    type="button"
+                    class="btn btn-primary btn-xs"
+                    onclick={() => handleJoin(channel.id)}
+                  >
+                    Join
+                  </button>
+                {:else}
+                  <span class="text-success text-xs">Joined</span>
+                {/if}
+              </div>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </div>
+
+    <div class="modal-action">
+      <button type="button" class="btn btn-ghost btn-sm" onclick={onClose}>
+        Close
+      </button>
+    </div>
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button type="submit">close</button>
+  </form>
+</dialog>

--- a/apps/desktop/src/components/channels/ChannelContextMenu.svelte
+++ b/apps/desktop/src/components/channels/ChannelContextMenu.svelte
@@ -2,17 +2,20 @@
   import ChevronRight from "@lucide/svelte/icons/chevron-right";
   import FolderInput from "@lucide/svelte/icons/folder-input";
   import FolderOutput from "@lucide/svelte/icons/folder-output";
+  import LogOut from "@lucide/svelte/icons/log-out";
   import Pencil from "@lucide/svelte/icons/pencil";
   import Trash2 from "@lucide/svelte/icons/trash-2";
-  import type { ChannelGroup } from "@packages/api-client";
+  import type { Channel, ChannelGroup } from "@packages/api-client";
 
   interface Props {
     x: number;
     y: number;
+    channelType: Channel["type"];
     currentGroupId: string | null;
     groups: ChannelGroup[];
     onEdit: () => void;
     onDelete: () => void;
+    onLeave?: () => void;
     onMoveToGroup: (groupId: string | null) => void;
     onClose: () => void;
   }
@@ -20,13 +23,17 @@
   const {
     x,
     y,
+    channelType,
     currentGroupId,
     groups,
     onEdit,
     onDelete,
+    onLeave,
     onMoveToGroup,
     onClose,
   }: Props = $props();
+
+  const canLeave = $derived(channelType !== "default");
 
   let showMoveSubmenu = $state(false);
 
@@ -37,6 +44,11 @@
 
   function handleDelete() {
     onDelete();
+    onClose();
+  }
+
+  function handleLeave() {
+    onLeave?.();
     onClose();
   }
 
@@ -126,6 +138,17 @@
     >
       <FolderOutput class="size-4" />
       Remove from Group
+    </button>
+  {/if}
+
+  {#if canLeave}
+    <button
+      type="button"
+      class="btn btn-ghost btn-sm justify-start gap-2"
+      onclick={handleLeave}
+    >
+      <LogOut class="size-4" />
+      Leave Channel
     </button>
   {/if}
 

--- a/apps/desktop/src/components/channels/ChannelGroup.svelte
+++ b/apps/desktop/src/components/channels/ChannelGroup.svelte
@@ -29,6 +29,7 @@
     onDelete?: (groupId: string) => void;
     onEditChannel?: (channel: Channel) => void;
     onDeleteChannel?: (channelId: string) => void;
+    onLeaveChannel?: (channelId: string) => void;
     onMoveChannelToGroup?: (channelId: string, groupId: string | null) => void;
   }
 
@@ -50,6 +51,7 @@
     onDelete,
     onEditChannel,
     onDeleteChannel,
+    onLeaveChannel,
     onMoveChannelToGroup,
   }: Props = $props();
 
@@ -105,6 +107,7 @@
           groups={allGroups}
           onEdit={onEditChannel}
           onDelete={onDeleteChannel}
+          onLeave={onLeaveChannel}
           onMoveToGroup={onMoveChannelToGroup}
         />
       {/each}
@@ -128,6 +131,7 @@
           {onDelete}
           {onEditChannel}
           {onDeleteChannel}
+          {onLeaveChannel}
           {onMoveChannelToGroup}
         />
       {/each}

--- a/apps/desktop/src/components/channels/ChannelItem.svelte
+++ b/apps/desktop/src/components/channels/ChannelItem.svelte
@@ -12,6 +12,7 @@
     groups?: ChannelGroup[];
     onEdit?: (channel: Channel) => void;
     onDelete?: (channelId: string) => void;
+    onLeave?: (channelId: string) => void;
     onMoveToGroup?: (channelId: string, groupId: string | null) => void;
   }
 
@@ -24,6 +25,7 @@
     groups = [],
     onEdit,
     onDelete,
+    onLeave,
     onMoveToGroup,
   }: Props = $props();
 
@@ -39,10 +41,12 @@
   <ChannelContextMenu
     x={contextMenu.x}
     y={contextMenu.y}
+    channelType={channel.type}
     currentGroupId={channel.groupId ?? null}
     {groups}
     onEdit={() => onEdit?.(channel)}
     onDelete={() => onDelete?.(channel.id)}
+    onLeave={() => onLeave?.(channel.id)}
     onMoveToGroup={(groupId) => onMoveToGroup?.(channel.id, groupId)}
     onClose={() => (contextMenu = null)}
   />

--- a/apps/desktop/src/components/channels/ChannelList.controller.svelte.ts
+++ b/apps/desktop/src/components/channels/ChannelList.controller.svelte.ts
@@ -20,15 +20,25 @@ export class ChannelListController {
   unreadManager;
   groupState;
 
+  // Filter to show only joined channels in sidebar
+  #joinedChannels: Channel[] = $derived.by(() =>
+    (this.channels.data ?? []).filter((ch) => ch.joined),
+  );
+
   #organized: GroupedChannels = $derived.by(() =>
     organizeChannelsIntoGroups(
-      this.channels.data ?? [],
+      this.#joinedChannels,
       this.channelGroups.data ?? [],
     ),
   );
 
   get organized() {
     return this.#organized;
+  }
+
+  // All channels (for channel browser)
+  get allChannels() {
+    return this.channels.data ?? [];
   }
 
   get rootGroups() {
@@ -159,5 +169,35 @@ export class ChannelListController {
 
   refetchChannels() {
     this.channels.refetch();
+  }
+
+  async joinChannel(channelId: string) {
+    try {
+      await this.#api.channels({ id: channelId }).join.post();
+      this.channels.refetch();
+      showToast("Joined channel", "success");
+    } catch (error) {
+      showToast("Failed to join channel", "error");
+      throw error;
+    }
+  }
+
+  async leaveChannel(channelId: string) {
+    const confirmed = await confirm({
+      title: "Leave Channel",
+      message: "Are you sure you want to leave this channel?",
+      confirmText: "Leave",
+      variant: "danger",
+    });
+    if (!confirmed) return;
+
+    try {
+      await this.#api.channels({ id: channelId }).leave.post();
+      this.channels.refetch();
+      showToast("Left channel", "success");
+    } catch (error) {
+      showToast("Failed to leave channel", "error");
+      throw error;
+    }
   }
 }

--- a/apps/desktop/src/components/channels/ChannelList.svelte
+++ b/apps/desktop/src/components/channels/ChannelList.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import FolderPlus from "@lucide/svelte/icons/folder-plus";
+  import Hash from "@lucide/svelte/icons/hash";
   import Plus from "@lucide/svelte/icons/plus";
   import User from "@lucide/svelte/icons/user";
   import type { Selection } from "$components/chat/types";
+  import ChannelBrowser from "./ChannelBrowser.svelte";
   import ChannelGroup from "./ChannelGroup.svelte";
   import ChannelItem from "./ChannelItem.svelte";
   import { ChannelListController } from "./ChannelList.controller.svelte.ts";
@@ -31,6 +33,13 @@
         Channels
       </span>
       <div class="flex items-center gap-1">
+        <button
+          class="btn btn-ghost btn-xs btn-square"
+          title="Browse channels"
+          onclick={() => modals.openBrowseChannels()}
+        >
+          <Hash class="text-muted size-4" />
+        </button>
         <button
           class="btn btn-ghost btn-xs btn-square"
           title="New group"
@@ -70,6 +79,7 @@
             onDelete={(id) => controller.deleteGroup(id)}
             onEditChannel={(ch) => modals.openEditChannel(ch)}
             onDeleteChannel={(id) => controller.deleteChannel(id)}
+            onLeaveChannel={(id) => controller.leaveChannel(id)}
             onMoveChannelToGroup={(chId, gId) =>
               controller.moveChannelToGroup(chId, gId)}
           />
@@ -89,6 +99,7 @@
             groups={controller.organized.groups}
             onEdit={(ch) => modals.openEditChannel(ch)}
             onDelete={(id) => controller.deleteChannel(id)}
+            onLeave={(id) => controller.leaveChannel(id)}
             onMoveToGroup={(chId, gId) =>
               controller.moveChannelToGroup(chId, gId)}
           />
@@ -137,6 +148,13 @@
     channel={modals.editChannel.channel}
     onClose={() => modals.closeEditChannel()}
     onSave={(id, name, desc) => controller.editChannel(id, name, desc)}
+  />
+
+  <ChannelBrowser
+    channels={controller.allChannels}
+    isOpen={modals.browseChannels.isOpen}
+    onClose={() => modals.closeBrowseChannels()}
+    onJoin={(id) => controller.joinChannel(id)}
   />
 
   <DMSection

--- a/apps/desktop/src/components/channels/modals.svelte.ts
+++ b/apps/desktop/src/components/channels/modals.svelte.ts
@@ -26,7 +26,12 @@ interface EditChannelModalState {
   channel: Channel | null;
 }
 
+interface BrowseChannelsModalState {
+  isOpen: boolean;
+}
+
 class ChannelModals {
+  browseChannels = $state<BrowseChannelsModalState>({ isOpen: false });
   createChannel = $state<CreateChannelModalState>({
     isOpen: false,
     defaultGroupId: null,
@@ -78,6 +83,14 @@ class ChannelModals {
 
   closeEditChannel() {
     this.editChannel = { isOpen: false, channel: null };
+  }
+
+  openBrowseChannels() {
+    this.browseChannels = { isOpen: true };
+  }
+
+  closeBrowseChannels() {
+    this.browseChannels = { isOpen: false };
   }
 }
 

--- a/apps/server/src/db/channels.ts
+++ b/apps/server/src/db/channels.ts
@@ -13,7 +13,7 @@ export const channels = pgTable(
     id: uuid("id").primaryKey().defaultRandom(),
     name: text("name").notNull(),
     description: text("description"),
-    type: text("type", { enum: ["public", "private", "dm"] })
+    type: text("type", { enum: ["default", "public", "private", "dm"] })
       .notNull()
       .default("public"),
     organizationId: uuid("organization_id")

--- a/apps/server/src/domains/channels/routes.ts
+++ b/apps/server/src/domains/channels/routes.ts
@@ -1,7 +1,7 @@
-import { asc, eq } from "drizzle-orm";
+import { and, asc, count, eq, sql } from "drizzle-orm";
 import { Elysia, t } from "elysia";
 import { db } from "../../db/index.ts";
-import { channels } from "../../db/schema.ts";
+import { channelMembers, channels } from "../../db/schema.ts";
 import {
   BadRequestError,
   ForbiddenError,
@@ -26,13 +26,31 @@ export const channelRoutes = new Elysia({ prefix: "/channels" })
 
       await getOrganizationPermissions(user.id, query.organizationId);
 
+      // Get channels with membership info and member counts
       const channelList = await db
-        .select()
+        .select({
+          id: channels.id,
+          name: channels.name,
+          description: channels.description,
+          type: channels.type,
+          organizationId: channels.organizationId,
+          groupId: channels.groupId,
+          createdAt: channels.createdAt,
+          updatedAt: channels.updatedAt,
+          memberCount: count(channelMembers.id),
+          joined: sql<boolean>`bool_or(${channelMembers.userId} = ${user.id})`,
+        })
         .from(channels)
+        .leftJoin(channelMembers, eq(channels.id, channelMembers.channelId))
         .where(eq(channels.organizationId, query.organizationId))
+        .groupBy(channels.id)
         .orderBy(asc(channels.name));
 
-      return channelList;
+      // For default channels, everyone is considered joined
+      return channelList.map((ch) => ({
+        ...ch,
+        joined: ch.type === "default" ? true : (ch.joined ?? false),
+      }));
     } catch (error) {
       return handleError(error, set);
     }
@@ -216,6 +234,88 @@ export const channelRoutes = new Elysia({ prefix: "/channels" })
       }
 
       await db.delete(channels).where(eq(channels.id, params.id));
+
+      return { success: true };
+    } catch (error) {
+      return handleError(error, set);
+    }
+  })
+  .post("/:id/join", async ({ user, params, set }) => {
+    try {
+      if (!user) throw new UnauthorizedError();
+
+      const [channel] = await db
+        .select()
+        .from(channels)
+        .where(eq(channels.id, params.id))
+        .limit(1);
+
+      if (!channel) throw new NotFoundError("Channel", "CHANNEL_NOT_FOUND");
+
+      await getOrganizationPermissions(user.id, channel.organizationId);
+
+      // Only public channels can be joined freely
+      if (channel.type !== "public") {
+        throw new ForbiddenError(
+          "Only public channels can be joined",
+          "CANNOT_JOIN_CHANNEL",
+        );
+      }
+
+      // Check if already a member (idempotent)
+      const [existing] = await db
+        .select()
+        .from(channelMembers)
+        .where(
+          and(
+            eq(channelMembers.channelId, params.id),
+            eq(channelMembers.userId, user.id),
+          ),
+        )
+        .limit(1);
+
+      if (!existing) {
+        await db.insert(channelMembers).values({
+          channelId: params.id,
+          userId: user.id,
+        });
+      }
+
+      return { success: true };
+    } catch (error) {
+      return handleError(error, set);
+    }
+  })
+  .post("/:id/leave", async ({ user, params, set }) => {
+    try {
+      if (!user) throw new UnauthorizedError();
+
+      const [channel] = await db
+        .select()
+        .from(channels)
+        .where(eq(channels.id, params.id))
+        .limit(1);
+
+      if (!channel) throw new NotFoundError("Channel", "CHANNEL_NOT_FOUND");
+
+      await getOrganizationPermissions(user.id, channel.organizationId);
+
+      // Cannot leave default channels
+      if (channel.type === "default") {
+        throw new ForbiddenError(
+          "Cannot leave default channels",
+          "CANNOT_LEAVE_CHANNEL",
+        );
+      }
+
+      await db
+        .delete(channelMembers)
+        .where(
+          and(
+            eq(channelMembers.channelId, params.id),
+            eq(channelMembers.userId, user.id),
+          ),
+        );
 
       return { success: true };
     } catch (error) {

--- a/apps/server/src/domains/organizations/members-add.ts
+++ b/apps/server/src/domains/organizations/members-add.ts
@@ -1,7 +1,12 @@
 import { and, eq } from "drizzle-orm";
 import { Elysia, t } from "elysia";
 import { db } from "../../db/index.ts";
-import { organizationMembers, users } from "../../db/schema.ts";
+import {
+  channelMembers,
+  channels,
+  organizationMembers,
+  users,
+} from "../../db/schema.ts";
 import { authMiddleware } from "../../middleware/auth.ts";
 import { getOrganizationPermissions } from "./permissions.ts";
 
@@ -62,6 +67,26 @@ export const organizationMemberAddRoute = new Elysia().use(authMiddleware).post(
         permission: body.permission,
       })
       .returning();
+
+    // Auto-join all default channels in this organization
+    const defaultChannels = await db
+      .select({ id: channels.id })
+      .from(channels)
+      .where(
+        and(
+          eq(channels.organizationId, params.id),
+          eq(channels.type, "default"),
+        ),
+      );
+
+    if (defaultChannels.length > 0) {
+      await db.insert(channelMembers).values(
+        defaultChannels.map((ch) => ({
+          channelId: ch.id,
+          userId: body.userId,
+        })),
+      );
+    }
 
     return membership;
   },

--- a/packages/api-client/src/types.ts
+++ b/packages/api-client/src/types.ts
@@ -34,9 +34,11 @@ export interface Channel {
   id: string;
   name: string;
   description?: string | null;
-  type: "public" | "private" | "dm";
+  type: "default" | "public" | "private" | "dm";
   organizationId: string;
   groupId?: string | null;
+  joined: boolean;
+  memberCount: number;
   createdAt: Date;
   updatedAt: Date;
 }


### PR DESCRIPTION
## Summary

- Slack風のチャンネル参加/退出機能を実装
- ユーザーがpublicチャンネルを発見・参加・退出できるように
- defaultチャンネルは全員自動参加、退出不可

## Changes

### Backend
- チャンネルタイプに `default` を追加
- `GET /channels` に `joined`, `memberCount` フィールドを追加
- `POST /channels/:id/join` - publicチャンネルへの参加
- `POST /channels/:id/leave` - チャンネルからの退出
- 組織メンバー追加時にdefaultチャンネルへ自動参加

### Frontend
- サイドバーに参加済みチャンネルのみ表示
- ChannelBrowserモーダル（publicチャンネル一覧、検索機能）
- コンテキストメニューにLeave機能追加

## Test plan

- [ ] publicチャンネルをChannelBrowserから参加できる
- [ ] 参加したチャンネルがサイドバーに表示される
- [ ] コンテキストメニューからチャンネルを退出できる
- [ ] defaultチャンネルはLeaveオプションが表示されない
- [ ] 新しい組織メンバーがdefaultチャンネルに自動参加する